### PR TITLE
Complete transaction before sleeping for polling interval

### DIFF
--- a/pkg/sql/subscriber.go
+++ b/pkg/sql/subscriber.go
@@ -80,7 +80,7 @@ type Subscriber struct {
 	consumerIdBytes  []byte
 	consumerIdString string
 
-	db   beginner
+	db     beginner
 	config SubscriberConfig
 
 	subscribeWg *sync.WaitGroup
@@ -222,7 +222,7 @@ func (s *Subscriber) query(
 			}
 		} else {
 			commitErr := tx.Commit()
-			if commitErr != nil {
+			if commitErr != nil && commitErr != sql.ErrTxDone {
 				logger.Error("could not commit tx for querying message", commitErr, nil)
 			}
 		}
@@ -245,6 +245,7 @@ func (s *Subscriber) query(
 		logger.Debug("No more messages, waiting until next query", watermill.LogFields{
 			"wait_time": s.config.PollInterval,
 		})
+		tx.Rollback()
 		time.Sleep(s.config.PollInterval)
 		return "", nil
 	} else if err != nil {


### PR DESCRIPTION
The subscriber query method is responsible for sleeping for the polling interval
when there are no remaining messages. It relies on the `defer`'d cleanup to
either commit or rollback the transaction.

In production deployments the polling interval may be greater than the
transaction idle limit, sometimes significantly so.

In that situation, the transaction will be terminated by the database server
before `query` returns, thereby causing the commit to fail.

This commit smooths this over by explicitly rolling back the transaction when
there are no messages to consume.