### PR TITLE
Make DB interfaces exported

### DIFF
--- a/pkg/sql/publisher.go
+++ b/pkg/sql/publisher.go
@@ -40,7 +40,7 @@ func (c *PublisherConfig) setDefaults() {
 type Publisher struct {
 	config PublisherConfig
 
-	db contextExecutor
+	db ContextExecutor
 
 	publishWg *sync.WaitGroup
 	closeCh   chan struct{}
@@ -50,7 +50,7 @@ type Publisher struct {
 	logger            watermill.LoggerAdapter
 }
 
-func NewPublisher(db contextExecutor, config PublisherConfig, logger watermill.LoggerAdapter) (*Publisher, error) {
+func NewPublisher(db ContextExecutor, config PublisherConfig, logger watermill.LoggerAdapter) (*Publisher, error) {
 	config.setDefaults()
 	if err := config.validate(); err != nil {
 		return nil, errors.Wrap(err, "invalid config")
@@ -161,7 +161,7 @@ func (p *Publisher) Close() error {
 	return nil
 }
 
-func isTx(db contextExecutor) bool {
+func isTx(db ContextExecutor) bool {
 	_, dbIsTx := db.(interface {
 		Commit() error
 		Rollback() error

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -11,7 +11,7 @@ func initializeSchema(
 	ctx context.Context,
 	topic string,
 	logger watermill.LoggerAdapter,
-	db contextExecutor,
+	db ContextExecutor,
 	schemaAdapter SchemaAdapter,
 	offsetsAdapter OffsetsAdapter,
 ) error {

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -9,26 +9,26 @@ import (
 
 // interface definitions borrowed from github.com/volatiletech/sqlboiler
 
-// executor can perform SQL queries.
-type executor interface {
+// Executor can perform SQL queries.
+type Executor interface {
 	Exec(query string, args ...interface{}) (sql.Result, error)
 	Query(query string, args ...interface{}) (*sql.Rows, error)
 	QueryRow(query string, args ...interface{}) *sql.Row
 }
 
-// contextExecutor can perform SQL queries with context
-type contextExecutor interface {
-	executor
+// ContextExecutor can perform SQL queries with context
+type ContextExecutor interface {
+	Executor
 
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
-// beginner begins transactions.
-type beginner interface {
+// Beginner begins transactions.
+type Beginner interface {
 	BeginTx(context.Context, *sql.TxOptions) (*sql.Tx, error)
-	contextExecutor
+	ContextExecutor
 }
 
 // sqlArgsToLog is used for "lazy" generating sql args strings to logger

--- a/pkg/sql/subscriber.go
+++ b/pkg/sql/subscriber.go
@@ -86,7 +86,7 @@ type Subscriber struct {
 	consumerIdBytes  []byte
 	consumerIdString string
 
-	db     beginner
+	db     Beginner
 	config SubscriberConfig
 
 	subscribeWg *sync.WaitGroup
@@ -96,7 +96,7 @@ type Subscriber struct {
 	logger watermill.LoggerAdapter
 }
 
-func NewSubscriber(db beginner, config SubscriberConfig, logger watermill.LoggerAdapter) (*Subscriber, error) {
+func NewSubscriber(db Beginner, config SubscriberConfig, logger watermill.LoggerAdapter) (*Subscriber, error) {
 	if db == nil {
 		return nil, errors.New("db is nil")
 	}


### PR DESCRIPTION
Change DB interfaces to exported to make it easier to create decorators or wrappers of publishers and subscribers.