### PR TITLE
Fix potential logger leakage in subscriber

### DIFF
--- a/pkg/sql/subscriber.go
+++ b/pkg/sql/subscriber.go
@@ -195,7 +195,7 @@ func (s *Subscriber) consume(ctx context.Context, topic string, out chan *messag
 		}
 
 		messageUUID, noMsg, err := s.query(ctx, topic, out, logger)
-		logger = logger.With(watermill.LogFields{"message_uuid": messageUUID})
+		logger := logger.With(watermill.LogFields{"message_uuid": messageUUID})
 		backoff := s.config.BackoffManager.HandleError(logger, noMsg, err)
 		if backoff != 0 {
 			if err != nil {


### PR DESCRIPTION
Depending on logger implementation there could be logger leakage: every new iteration of loop could enrich a logger context indefinitely 