### PR TITLE
Isolation level for postgres should be repeatable read

### DIFF
--- a/pkg/sql/schema_adapter_postgresql.go
+++ b/pkg/sql/schema_adapter_postgresql.go
@@ -141,5 +141,5 @@ func (s DefaultPostgreSQLSchema) MessagesTable(topic string) string {
 
 func (s DefaultPostgreSQLSchema) SubscribeIsolationLevel() sql.IsolationLevel {
 	// For Postgres Repeatable Read is enough.
-	return sql.LevelSerializable
+	return sql.LevelRepeatableRead
 }


### PR DESCRIPTION
As already mentioned in the comment, the isolation level for postgres should be `sql.LevelRepeatableRead`.

With the current setting to `sql.LevelSerializable`, we are getting a lot of serialization errors, leading to rollback in watermil-sql and to duplicate handling of the entries in the outbox table.