### PR TITLE
fix: support MariaDB by making column names backticked

### DIFF
--- a/pkg/sql/schema_adapter_mysql.go
+++ b/pkg/sql/schema_adapter_mysql.go
@@ -88,13 +88,16 @@ func (s DefaultMySQLSchema) batchSize() int {
 
 func (s DefaultMySQLSchema) SelectQuery(topic string, consumerGroup string, offsetsAdapter OffsetsAdapter) (string, []interface{}) {
 	nextOffsetQuery, nextOffsetArgs := offsetsAdapter.NextOffsetQuery(topic, consumerGroup)
-	selectQuery := `
-		SELECT offset, uuid, payload, metadata FROM ` + s.MessagesTable(topic) + `
-		WHERE 
-			offset > (` + nextOffsetQuery + `)
-		ORDER BY 
-			offset ASC
-		LIMIT ` + fmt.Sprintf("%d", s.batchSize())
+
+	selectQuery := fmt.Sprintf(`
+	SELECT %s, %s, %s, %s
+	FROM %s
+	WHERE
+	    %s > (%s)
+	ORDER BY
+	    %s ASC
+	LIMIT %d
+`, backticks("offset"), backticks("uuid"), backticks("payload"), backticks("metadata"), s.MessagesTable(topic), backticks("offset"), nextOffsetQuery, backticks("offset"), s.batchSize())
 
 	return selectQuery, nextOffsetArgs
 }

--- a/pkg/sql/util.go
+++ b/pkg/sql/util.go
@@ -1,0 +1,17 @@
+package sql
+
+import (
+	"strings"
+)
+
+const (
+	backtick = "`"
+)
+
+func backticks(s string) string {
+	if strings.HasPrefix(s, backtick) && strings.HasSuffix(s, backtick) {
+		return s
+	}
+
+	return backtick + s + backtick
+}


### PR DESCRIPTION
Solve [ThreeDotsLabs/watermill issue#377](https://github.com/ThreeDotsLabs/watermill/issues/377)

---

The word `offset` in MariaDB is a keyword. Thus, MariaDB got error while parsing our SQL (https://github.com/ThreeDotsLabs/watermill-sql/blob/b6c85087b1cbd92a081186077ba1f8145ea6422e/pkg/sql/schema_adapter_mysql.go#L91C2-L97C45):

```sql
SELECT offset, uuid, payload, metadata FROM ...
```

So I add backticks to the column names to get the SQL like this:

```sql
SELECT `offset`, `uuid`, `payload`, `metadata` FROM ...
```

---

A MariaDB could be setup using the command as below:

```bash
docker run -p 3306:3306 --rm --env MARIADB_ROOT_PASSWORD=123456 --env MARIADB_DATABASE=test -d --name mariadb mariadb
```

My test code are shown as below:

```go
// main.go

// https://github.com/ThreeDotsLabs/watermill/blob/master/_examples/pubsubs/go-channel/main.go#L25

package main

import (
	"context"
	stdsql "database/sql"
	"log"
	"time"

	"github.com/ThreeDotsLabs/watermill"
	"github.com/ThreeDotsLabs/watermill/message"
	_ "github.com/go-sql-driver/mysql"

	"github.com/ThreeDotsLabs/watermill-sql/v2/pkg/sql"
)

func main() {
	db := must(stdsql.Open("mysql", "root:123456@tcp(127.0.0.1:3306)/test?loc=Local&parseTime=true"))
	defer db.Close()

	must0(db.Ping())

	logger := watermill.NewStdLogger(false, false)

	subscriber := must(sql.NewSubscriber(
		db,
		sql.SubscriberConfig{
			SchemaAdapter:    sql.DefaultMySQLSchema{},
			OffsetsAdapter:   sql.DefaultMySQLOffsetsAdapter{},
			InitializeSchema: true,
		},
		logger,
	))

	messages := must(subscriber.Subscribe(context.Background(), "example_topic"))

	go process(messages)

	publisher := must(sql.NewPublisher(
		db,
		sql.PublisherConfig{
			SchemaAdapter: sql.DefaultMySQLSchema{},
		},
		logger,
	))

	publishMessages(publisher)
}

func publishMessages(publisher message.Publisher) {
	for {
		msg := message.NewMessage(watermill.NewUUID(), []byte(`{"message": "Hello, world!"}`))

		if err := publisher.Publish("example_topic", msg); err != nil {
			panic(err)
		}

		time.Sleep(time.Second)
	}
}

func process(messages <-chan *message.Message) {
	for msg := range messages {
		log.Printf("received message: %s, payload: %s", msg.UUID, string(msg.Payload))
		msg.Ack()
	}
}

func must[T any](data T, err error) T {
	if err != nil {
		panic(err)
	}
	return data
}

func must0(err error) {
	if err != nil {
		panic(err)
	}
}
```