### PR TITLE
Adding `comfylite3`

### DIFF
--- a/pkg/sql/offsets_adapter_comfylite3.go
+++ b/pkg/sql/offsets_adapter_comfylite3.go
@@ -1,0 +1,76 @@
+package sql
+
+import "fmt"
+
+// DefaultComfylite3OffsetsAdapter is a default implementation of OffsetsAdapter based on Comfylite3. You could eventually use any other sqlite3 drivers, but you might have trouble depending on which one you will use. One common error you will encounter will be `database locked` when the driver is not handling the concurrent access properly.
+//
+// `comfylite3` is wrapper of [the famous go-sqlite3](https://github.com/mattn/go-sqlite3) driver which compensate the lack of goroutine management by giving the illusion of it. Most other libraries that re-implement the entire sqlite3 driver won't support the latest features, like the recent JSON datatype, sometimes you just want it all!
+//
+// Since you will need to provide a *sql.DB instance to the SQL adapter, you will need to use the `comfylite3` driver instead of the `go-sqlite3` driver.
+//
+// ```go
+// go get -u github.com/davidroman0O/comfylite3
+// ```
+//
+// Once you have the `comfylite3` driver, you can use the `comfylite3` driver in the following way:
+//
+// ```go
+// comfydb, _ := comfylite3.Comfy(comfylite3.WithMemory()) // Options: WithMemory() or Withfile("path/to/file.db") or even writting your own connection WithConnection("file::memory:?_mutex=full&cache=shared&_timeout=5000")
+// ```
+//
+// Then you can use the `comfydb` instance as the first parameter of `sql.NewSubscriber` or `sql.NewPublisher`.
+//
+// `comfydb` is exposing the interface of *sql.DB which allow you to use it as a regular driver, now you can have it all!
+type DefaultComfylite3OffsetsAdapter struct {
+	// GenerateMessagesOffsetsTableName may be used to override how the messages/offsets table name is generated.
+	GenerateMessagesOffsetsTableName func(topic string) string
+}
+
+func (a DefaultComfylite3OffsetsAdapter) SchemaInitializingQueries(topic string) []Query {
+	return []Query{
+		{
+			Query: `
+				CREATE TABLE IF NOT EXISTS ` + a.MessagesOffsetsTable(topic) + ` (
+				consumer_group TEXT NOT NULL,
+				offset_acked INTEGER,
+				offset_consumed INTEGER NOT NULL,
+				PRIMARY KEY(consumer_group)
+			)`,
+		},
+	}
+}
+
+func (a DefaultComfylite3OffsetsAdapter) AckMessageQuery(topic string, row Row, consumerGroup string) Query {
+	ackQuery := `INSERT INTO ` + a.MessagesOffsetsTable(topic) + ` (offset_consumed, offset_acked, consumer_group)
+		VALUES (?, ?, ?) ON CONFLICT(consumer_group) DO UPDATE SET offset_consumed=excluded.offset_consumed, offset_acked=excluded.offset_acked`
+
+	return Query{ackQuery, []any{row.Offset, row.Offset, consumerGroup}}
+}
+
+func (a DefaultComfylite3OffsetsAdapter) NextOffsetQuery(topic, consumerGroup string) Query {
+	return Query{
+		Query: `SELECT COALESCE(
+				(SELECT offset_acked
+				 FROM ` + a.MessagesOffsetsTable(topic) + `
+				 WHERE consumer_group=?
+				), 0)`,
+		Args: []any{consumerGroup},
+	}
+}
+
+func (a DefaultComfylite3OffsetsAdapter) MessagesOffsetsTable(topic string) string {
+	if a.GenerateMessagesOffsetsTableName != nil {
+		return a.GenerateMessagesOffsetsTableName(topic)
+	}
+	return fmt.Sprintf("watermill_offsets_%s", topic)
+}
+
+func (a DefaultComfylite3OffsetsAdapter) ConsumedMessageQuery(topic string, row Row, consumerGroup string, consumerULID []byte) Query {
+	ackQuery := `INSERT INTO ` + a.MessagesOffsetsTable(topic) + ` (offset_consumed, consumer_group)
+		VALUES (?, ?) ON CONFLICT(consumer_group) DO UPDATE SET offset_consumed=excluded.offset_consumed`
+	return Query{ackQuery, []interface{}{row.Offset, consumerGroup}}
+}
+
+func (a DefaultComfylite3OffsetsAdapter) BeforeSubscribingQueries(topic, consumerGroup string) []Query {
+	return nil
+}

--- a/pkg/sql/schema_adapter_comfylite3.go
+++ b/pkg/sql/schema_adapter_comfylite3.go
@@ -1,0 +1,124 @@
+package sql
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	stdSQL "database/sql"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+)
+
+// DefaultSQLite3Schema is a default implementation of SchemaAdapter based on Comfylite3. You could eventually use any other sqlite3 drivers, but you might have trouble depending on which one you will use. One common error you will encounter will be `database locked` when the driver is not handling the concurrent access properly.
+//
+// `comfylite3` is wrapper of [the famous go-sqlite3](https://github.com/mattn/go-sqlite3) driver which compensate the lack of goroutine management by giving the illusion of it. Most other libraries that re-implement the entire sqlite3 driver won't support the latest features, like the recent JSON datatype, sometimes you just want it all!
+//
+// Since you will need to provide a *sql.DB instance to the SQL adapter, you will need to use the `comfylite3` driver instead of the `go-sqlite3` driver.
+//
+// ```go
+// go get -u github.com/davidroman0O/comfylite3
+// ```
+//
+// Once you have the `comfylite3` driver, you can use the `comfylite3` driver in the following way:
+//
+// ```go
+// comfydb, _ := comfylite3.Comfy(comfylite3.WithMemory()) // Options: WithMemory() or Withfile("path/to/file.db") or even writting your own connection WithConnection("file::memory:?_mutex=full&cache=shared&_timeout=5000")
+// ```
+//
+// Then you can use the `comfydb` instance as the first parameter of `sql.NewSubscriber` or `sql.NewPublisher`.
+//
+// `comfydb` is exposing the interface of *sql.DB which allow you to use it as a regular driver, now you can have it all!
+type DefaultSQLite3Schema struct {
+	// GenerateMessagesTableName may be used to override how the messages table name is generated.
+	GenerateMessagesTableName func(topic string) string
+
+	// SubscribeBatchSize is the number of messages to be queried at once.
+	//
+	// Higher value, increases a chance of message re-delivery in case of crash or networking issues.
+	// 1 is the safest value, but it may have a negative impact on performance when consuming a lot of messages.
+	//
+	// Default value is 100.
+	SubscribeBatchSize int
+}
+
+func (s DefaultSQLite3Schema) SchemaInitializingQueries(topic string) []Query {
+	createMessagesTable := strings.Join([]string{
+		"CREATE TABLE IF NOT EXISTS " + s.MessagesTable(topic) + " (",
+		"`offset` INTEGER PRIMARY KEY AUTOINCREMENT,",
+		"`uuid` TEXT NOT NULL,",
+		"`created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,",
+		"`payload` TEXT,",
+		"`metadata` TEXT",
+		");",
+	}, "\n")
+
+	return []Query{{Query: createMessagesTable}}
+}
+
+func (s DefaultSQLite3Schema) InsertQuery(topic string, msgs message.Messages) (Query, error) {
+	insertQuery := fmt.Sprintf(
+		`INSERT INTO %s (uuid, payload, metadata) VALUES %s`,
+		s.MessagesTable(topic),
+		strings.TrimRight(strings.Repeat(`(?,?,?),`, len(msgs)), ","),
+	)
+
+	args, err := defaultInsertArgs(msgs)
+	if err != nil {
+		return Query{}, err
+	}
+
+	return Query{insertQuery, args}, nil
+}
+
+func (s DefaultSQLite3Schema) batchSize() int {
+	if s.SubscribeBatchSize == 0 {
+		return 100
+	}
+
+	return s.SubscribeBatchSize
+}
+
+func (s DefaultSQLite3Schema) SelectQuery(topic string, consumerGroup string, offsetsAdapter OffsetsAdapter) Query {
+	nextOffsetQuery := offsetsAdapter.NextOffsetQuery(topic, consumerGroup)
+
+	selectQuery := "SELECT `offset`, `uuid`, `payload`, `metadata` FROM " + s.MessagesTable(topic) +
+		" WHERE `offset` > (" + nextOffsetQuery.Query + ") ORDER BY `offset` ASC" +
+		` LIMIT ` + fmt.Sprintf("%d", s.batchSize())
+
+	return Query{Query: selectQuery, Args: nextOffsetQuery.Args}
+}
+
+func (s DefaultSQLite3Schema) UnmarshalMessage(row Scanner) (Row, error) {
+	r := Row{}
+	err := row.Scan(&r.Offset, &r.UUID, &r.Payload, &r.Metadata)
+	if err != nil {
+		return Row{}, errors.Join(err, errors.New("could not scan message row"))
+	}
+
+	msg := message.NewMessage(string(r.UUID), []byte(r.Payload))
+
+	if r.Metadata != nil {
+		err = json.Unmarshal([]byte(r.Metadata), &msg.Metadata)
+		if err != nil {
+			return Row{}, errors.Join(err, errors.New("could not unmarshal metadata as JSON"))
+		}
+	}
+
+	r.Msg = msg
+
+	return r, nil
+}
+
+func (s DefaultSQLite3Schema) MessagesTable(topic string) string {
+	if s.GenerateMessagesTableName != nil {
+		return s.GenerateMessagesTableName(topic)
+	}
+	return fmt.Sprintf("watermill_%s", topic)
+}
+
+func (s DefaultSQLite3Schema) SubscribeIsolationLevel() stdSQL.IsolationLevel {
+	// SQLite does not support isolation levels, so we return the default level.
+	return stdSQL.LevelDefault
+}


### PR DESCRIPTION
Adding the [`comfylite3`](https://github.com/davidroman0O/comfylite3) wrapper of [the famous go-sqlite3](https://github.com/mattn/go-sqlite3) driver which compensate the lack of goroutine support by giving the illusion of it. 

Most other libraries that re-implement the entire sqlite3 driver won't support the latest features, like the recent JSON datatype, sometimes you just want it all!

No dependency added, very similar to the mysql implementation, eventually someone else would want to add a specific sqlite implementation for a pure golang version since [go-sqlite3](https://github.com/mattn/go-sqlite3) might require CGO!

At least, it gives more options! Using sqlite3 with watermill for small side projects is very cool, especially when using an adapter pattern to switch between a real mysql to sqlite3 with the same implementation!

Nothing fancy in the code! 😄 