### PR TITLE
Remove unused interfaces

### DIFF
--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -9,20 +9,10 @@ import (
 
 // interface definitions borrowed from github.com/volatiletech/sqlboiler
 
-// Executor can perform SQL queries.
-type Executor interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	QueryRow(query string, args ...interface{}) *sql.Row
-}
-
 // ContextExecutor can perform SQL queries with context
 type ContextExecutor interface {
-	Executor
-
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
-	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
 // Beginner begins transactions.


### PR DESCRIPTION
Watermill-SQL only actually uses ExecContext and QueryContext, which is all [Ent](https://entgo.io/) provides via the [SQL Raw API](https://entgo.io/docs/feature-flags/#sql-raw-api), I've trimmed the interfaces down so they are compatible. 