### PR TITLE
Use errors and fmt package to wrap errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/jackc/pgx/v4 v4.8.1
 	github.com/lib/pq v1.3.0
 	github.com/oklog/ulid v1.3.1
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.1
 )
 
@@ -25,6 +24,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.4.2 // indirect
 	github.com/lithammer/shortuuid/v3 v3.0.7 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect

--- a/pkg/sql/publisher.go
+++ b/pkg/sql/publisher.go
@@ -2,9 +2,9 @@ package sql
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
-
-	"github.com/pkg/errors"
 
 	"github.com/ThreeDotsLabs/watermill"
 	"github.com/ThreeDotsLabs/watermill/message"
@@ -53,7 +53,7 @@ type Publisher struct {
 func NewPublisher(db ContextExecutor, config PublisherConfig, logger watermill.LoggerAdapter) (*Publisher, error) {
 	config.setDefaults()
 	if err := config.validate(); err != nil {
-		return nil, errors.Wrap(err, "invalid config")
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
 	if db == nil {
@@ -105,7 +105,7 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) (err err
 
 	insertQuery, err := p.config.SchemaAdapter.InsertQuery(topic, messages)
 	if err != nil {
-		return errors.Wrap(err, "cannot create insert query")
+		return fmt.Errorf("cannot create insert query: %w", err)
 	}
 
 	p.logger.Trace("Inserting message to SQL", watermill.LogFields{
@@ -115,7 +115,7 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) (err err
 
 	_, err = p.db.ExecContext(context.Background(), insertQuery.Query, insertQuery.Args...)
 	if err != nil {
-		return errors.Wrap(err, "could not insert message as row")
+		return fmt.Errorf("could not insert message as row: %w", err)
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (p *Publisher) initializeSchema(topic string) error {
 		p.config.SchemaAdapter,
 		nil,
 	); err != nil {
-		return errors.Wrap(err, "cannot initialize schema")
+		return fmt.Errorf("cannot initialize schema: %w", err)
 	}
 
 	p.initializedTopics.Store(topic, struct{}{})

--- a/pkg/sql/schema.go
+++ b/pkg/sql/schema.go
@@ -2,9 +2,9 @@ package sql
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill"
-	"github.com/pkg/errors"
 )
 
 func initializeSchema(
@@ -30,9 +30,9 @@ func initializeSchema(
 	})
 
 	for _, q := range initializingQueries {
-		_, err := db.ExecContext(ctx, q.Query, q.Args...)
+		_, err = db.ExecContext(ctx, q.Query, q.Args...)
 		if err != nil {
-			return errors.Wrap(err, "could not initialize schema")
+			return fmt.Errorf("could not initialize schema: %w", err)
 		}
 	}
 

--- a/pkg/sql/schema_adapter.go
+++ b/pkg/sql/schema_adapter.go
@@ -3,9 +3,9 @@ package sql
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 )
 
 // SchemaAdapter produces the SQL queries and arguments appropriately for a specific schema and dialect
@@ -49,7 +49,7 @@ func defaultInsertArgs(msgs message.Messages) ([]interface{}, error) {
 	for _, msg := range msgs {
 		metadata, err := json.Marshal(msg.Metadata)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not marshal metadata into JSON for message %s", msg.UUID)
+			return nil, fmt.Errorf("could not marshal metadata into JSON for message %s: %w", msg.UUID, err)
 		}
 
 		args = append(args, msg.UUID, []byte(msg.Payload), metadata)

--- a/pkg/sql/schema_adapter_mysql.go
+++ b/pkg/sql/schema_adapter_mysql.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 )
 
 // DefaultMySQLSchema is a default implementation of SchemaAdapter based on MySQL.
@@ -102,7 +101,7 @@ func (s DefaultMySQLSchema) UnmarshalMessage(row Scanner) (Row, error) {
 	r := Row{}
 	err := row.Scan(&r.Offset, &r.UUID, &r.Payload, &r.Metadata)
 	if err != nil {
-		return Row{}, errors.Wrap(err, "could not scan message row")
+		return Row{}, fmt.Errorf("could not scan message row: %w", err)
 	}
 
 	msg := message.NewMessage(string(r.UUID), r.Payload)
@@ -110,7 +109,7 @@ func (s DefaultMySQLSchema) UnmarshalMessage(row Scanner) (Row, error) {
 	if r.Metadata != nil {
 		err = json.Unmarshal(r.Metadata, &msg.Metadata)
 		if err != nil {
-			return Row{}, errors.Wrap(err, "could not unmarshal metadata as JSON")
+			return Row{}, fmt.Errorf("could not unmarshal metadata as JSON: %w", err)
 		}
 	}
 

--- a/pkg/sql/schema_adapter_postgresql.go
+++ b/pkg/sql/schema_adapter_postgresql.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/ThreeDotsLabs/watermill/message"
-	"github.com/pkg/errors"
 )
 
 // DefaultPostgreSQLSchema is a default implementation of SchemaAdapter based on PostgreSQL.
@@ -112,7 +111,7 @@ func (s DefaultPostgreSQLSchema) UnmarshalMessage(row Scanner) (Row, error) {
 
 	err := row.Scan(&r.Offset, &transactionID, &r.UUID, &r.Payload, &r.Metadata)
 	if err != nil {
-		return Row{}, errors.Wrap(err, "could not scan message row")
+		return Row{}, fmt.Errorf("could not scan message row: %w", err)
 	}
 
 	msg := message.NewMessage(string(r.UUID), r.Payload)
@@ -120,7 +119,7 @@ func (s DefaultPostgreSQLSchema) UnmarshalMessage(row Scanner) (Row, error) {
 	if r.Metadata != nil {
 		err = json.Unmarshal(r.Metadata, &msg.Metadata)
 		if err != nil {
-			return Row{}, errors.Wrap(err, "could not unmarshal metadata as JSON")
+			return Row{}, fmt.Errorf("could not unmarshal metadata as JSON: %w", err)
 		}
 	}
 

--- a/pkg/sql/topic.go
+++ b/pkg/sql/topic.go
@@ -1,9 +1,9 @@
 package sql
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
-
-	"github.com/pkg/errors"
 )
 
 var disallowedTopicCharacters = regexp.MustCompile(`[^A-Za-z0-9\-\$\:\.\_]`)
@@ -14,7 +14,7 @@ var ErrInvalidTopicName = errors.New("topic name should not contain characters m
 // Topics are translated into SQL tables and patched into some queries, so this is done to prevent injection as well.
 func validateTopicName(topic string) error {
 	if disallowedTopicCharacters.MatchString(topic) {
-		return errors.Wrap(ErrInvalidTopicName, topic)
+		return fmt.Errorf("%s: %w", topic, ErrInvalidTopicName)
 	}
 
 	return nil

--- a/pkg/sql/topic_test.go
+++ b/pkg/sql/topic_test.go
@@ -5,12 +5,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ThreeDotsLabs/watermill-sql/v3/pkg/sql"
-	"github.com/ThreeDotsLabs/watermill/message"
-
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/ThreeDotsLabs/watermill-sql/v3/pkg/sql"
+	"github.com/ThreeDotsLabs/watermill/message"
 )
 
 func TestValidateTopicName(t *testing.T) {
@@ -22,11 +21,11 @@ func TestValidateTopicName(t *testing.T) {
 
 	err := publisher.Publish(cleverlyNamedTopic, message.NewMessage("uuid", nil))
 	require.Error(t, err)
-	assert.Equal(t, sql.ErrInvalidTopicName, errors.Cause(err))
+	assert.ErrorIs(t, err, sql.ErrInvalidTopicName)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_, err = subscriber.Subscribe(ctx, cleverlyNamedTopic)
 	require.Error(t, err)
-	assert.Equal(t, sql.ErrInvalidTopicName, errors.Cause(err))
+	assert.ErrorIs(t, err, sql.ErrInvalidTopicName)
 }


### PR DESCRIPTION
Good day,

Thank you for reviewing this PR.

In this PR error wrapping is replaced to use `fmt.Errorf` with the `%w` format specifier (introduced in golang 1.13) instead of `errors.Wrap` which was provided by the `github.com/pkg/errors` package.

This is a followup from https://github.com/ThreeDotsLabs/watermill/pull/460.