### PR TITLE
Publish context

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Watermill SQL (Postgres/MySQL) Pub/Sub
 <img align="right" width="200" src="https://watermill.io/img/gopher.svg">
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Watermill SQL (Postgres/MySQL) Pub/Sub
 <img align="right" width="200" src="https://watermill.io/img/gopher.svg">
 

--- a/pkg/sql/publisher.go
+++ b/pkg/sql/publisher.go
@@ -117,7 +117,13 @@ func (p *Publisher) Publish(topic string, messages ...*message.Message) (err err
 		"query_args": sqlArgsToLog(insertQuery.Args),
 	})
 
-	_, err = p.db.ExecContext(context.Background(), insertQuery.Query, insertQuery.Args...)
+	var ctx context.Context
+	if len(messages) > 0 {
+		ctx = messages[0].Context()
+	} else {
+		ctx = context.Background()
+	}
+	_, err = p.db.ExecContext(ctx, insertQuery.Query, insertQuery.Args...)
 	if err != nil {
 		return fmt.Errorf("could not insert message as row: %w", err)
 	}


### PR DESCRIPTION
https://github.com/ThreeDotsLabs/watermill/issues/445

<!--
Thanks for contributing to Watermill!

The following template aims to help contributors write a good description for their pull requests.
**The more information you provide, the faster we will be able to review and merge your PR.**

Feel free to skip this template for minor changes like typo fixes.

-->

### Motivation / Background

I would like to instrument watermill-sql interactions with the database using open telemetry.  Automatic instrumentation requires propagating context from callers to the database client.

<!--

Explain the purpose of this Pull Request:
- What issue or bug does it address?
- What new functionality does it add?
- Why are these changes needed?
For bug fixes, include "Fixes #ISSUE" to automatically link to the related issue.

-->

### Details

`Message.SetContext()` can be used to propagate context to the framework, and defaults to `context.Background()` it has not been set.

### Alternative approaches considered (if applicable)

I considered updating the signature of `Publish` to take a context parameter, but that would be a breaking change to watermill and all supported vendors.

### Checklist

The resources of our team are limited. **There are a couple of things that you can do to help us merge your PR faster**:

- [ ] I wrote tests for the changes.
- [ ] All tests are passing.
  - If you are testing a Pub/Sub, you can start Docker with `make up`.
  - You can start with `make test_short` for a quick check.
  - If you want to run all tests, use `make test`.
- [ ] Code has no breaking changes.
- [ ] _(If applicable)_ documentation on [watermill.io](https://watermill.io/) is updated.
  - Documentation is built in the [github.com/ThreeDotsLabs/watermill/docs](https://github.com/ThreeDotsLabs/watermill/tree/master/docs).
  - You can find development instructions in the [DEVELOP.md](https://github.com/ThreeDotsLabs/watermill/tree/master/docs/DEVELOP.md).
