### PR TITLE
Fix logger error fields not clearing in the Subscriber consume method

### DIFF
--- a/pkg/sql/subscriber.go
+++ b/pkg/sql/subscriber.go
@@ -248,13 +248,14 @@ func (s *Subscriber) consume(ctx context.Context, topic string, out chan *messag
 		noMsg, err := s.query(ctx, topic, out, logger)
 		backoff := s.config.BackoffManager.HandleError(logger, noMsg, err)
 		if backoff != 0 {
-			if err != nil {
-				logger = logger.With(watermill.LogFields{"err": err.Error()})
-			}
-			logger.Trace("Backing off querying", watermill.LogFields{
+			logFields := watermill.LogFields{
 				"wait_time": backoff,
 				"no_msg":    noMsg,
-			})
+			}
+			if err != nil {
+				logFields.Add(watermill.LogFields{"err": err.Error()})
+			}
+			logger.Trace("Backing off querying", logFields)
 		}
 		sleepTime = backoff
 	}


### PR DESCRIPTION
### Motivation / Background

Error handling in the Subscriber's `consume` method overrides the logger with a logger with an `err` field set. This is never cleared, so the `err` field is logged even after the error is resolved.