### PR TITLE
Fix validation of subscriber ack deadline

### DIFF
--- a/pkg/sql/subscriber.go
+++ b/pkg/sql/subscriber.go
@@ -83,7 +83,7 @@ func (c SubscriberConfig) validate() error {
 	if c.AckDeadline == nil {
 		return errors.New("ack deadline is nil")
 	}
-	if c.AckDeadline != nil && *c.AckDeadline <= 0 {
+	if c.AckDeadline != nil && *c.AckDeadline < 0 {
 		return errors.New("ack deadline must be a positive duration")
 	}
 	if c.PollInterval <= 0 {


### PR DESCRIPTION
### Motivation / Background

As stated in the [documentation](https://github.com/ThreeDotsLabs/watermill-sql/blob/8309d5e35fc304991f12b216077c900800f5b8c8/pkg/sql/subscriber.go#L31), `AckDeadline` of subscriber configuration can be set to **zero** to disable it.

However, current config validation function disallow it. 